### PR TITLE
[FIX] History not clearing up on changing chatbot type

### DIFF
--- a/chatbot/constants.py
+++ b/chatbot/constants.py
@@ -48,6 +48,7 @@ HUMAN = "human"
 MESSAGE = "message"
 ROLE = "role"
 CONTENT = "content"
+CHATBOT_TYPE = "chatbot_type"
 
 # platform based constants
 LINUX = "Linux"
@@ -67,7 +68,7 @@ EXPERT = "Expert"
 DEFAULT = "Default"
 DOCBOT = "Docbot"
 
-CHATBOT_TYPE = [
+CHATBOT_TYPE_LIST = [
     THERAPIST,
     COMEDIAN,
     CHILD,

--- a/chatbot/engine.py
+++ b/chatbot/engine.py
@@ -8,7 +8,7 @@ from transformers import (
 
 from chatbot.constants import (
     CHAT_SEPARATOR,
-    CHATBOT_TYPE,
+    CHATBOT_TYPE_LIST,
     CREATIVE_LLM_TEMP,
     DEFAULT,
     DETERMINISTIC_LLM_TEMP,
@@ -52,9 +52,9 @@ class ChatbotEngine:
         self.prompts = PERSONALITY_PROMPTS
 
     def verify_chatbot_type(self, chatbot_type: str) -> str:
-        if chatbot_type not in CHATBOT_TYPE:
+        if chatbot_type not in CHATBOT_TYPE_LIST:
             raise ValueError(
-                f"Chatbot type `{chatbot_type}` is not supported. Choose from - {CHATBOT_TYPE}"
+                f"Chatbot type `{chatbot_type}` is not supported. Choose from - {CHATBOT_TYPE_LIST}"
             )
         if chatbot_type == DOCBOT and not self.with_doc:
             raise ValueError(f"Please provide `file_path` with `chatbot_type` = {DOCBOT}")

--- a/chatbot/streamlit/Home.py
+++ b/chatbot/streamlit/Home.py
@@ -8,9 +8,6 @@ st.set_page_config(
 )
 st.write("# 💭 Multi Functional Chatbot 🤖")
 
-_HOME = "home"
-st.session_state.page = _HOME
-
 
 def main() -> None:
     st.markdown("#### This is your multi-functional chatbot 🤖 with the following usage as of now:")

--- a/chatbot/streamlit/pages/📂_Chat_With_Doc.py
+++ b/chatbot/streamlit/pages/📂_Chat_With_Doc.py
@@ -10,8 +10,10 @@ from chatbot.constants import (
     ASSISTANT,
     CHAT_HISTORY,
     CHAT_SEPARATOR,
+    CHATBOT_TYPE,
     DATABASE,
     DETERMINISTIC_LLM_TEMP,
+    DOCBOT,
     EOS_TOKEN,
     MAX_NEW_TOKENS,
     PDF_FILE_PATH,
@@ -32,10 +34,8 @@ from chatbot.vector_database import get_vector_database
 
 st.title("💭 Your Own Chatbot with Doc 🤖")
 
-_CHAT_WITH_DOC = "chat_with_doc"
-
-st.session_state.page = _CHAT_WITH_DOC
 st.session_state[CHAT_HISTORY] = st.session_state.get(CHAT_HISTORY, [])
+st.session_state[CHATBOT_TYPE] = st.session_state.get(CHATBOT_TYPE, None)
 
 Output = TypeVar("Output")
 
@@ -57,7 +57,7 @@ class CustomDocChatbot:
     def __init__(self) -> None:
         with st.spinner("Loading Model..."):
             self.llm, self.tokenizer = load_llm_model()
-        chat_history_init(_CHAT_WITH_DOC)
+        chat_history_init(DOCBOT)
         self.avatar = {USER: "🐼", ASSISTANT: "🤖"}
         self.prompt_generator = PromptGenerator()
 

--- a/chatbot/streamlit/utils.py
+++ b/chatbot/streamlit/utils.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 import streamlit as st
 
-from chatbot.constants import CHAT_HISTORY, CHAT_SEPARATOR, LLM_MODEL
+from chatbot.constants import CHAT_HISTORY, CHAT_SEPARATOR, CHATBOT_TYPE, LLM_MODEL
 from chatbot.model import ModelLoader
 
 
@@ -13,10 +13,11 @@ class ChatMessage:
     message: str
 
 
-def chat_history_init(current_page: str) -> None:
-    if st.session_state.page != current_page:
+def chat_history_init(current_chatbot_type: str) -> None:
+    if st.session_state[CHATBOT_TYPE] != current_chatbot_type:
         del st.session_state[CHAT_HISTORY]
         st.session_state[CHAT_HISTORY] = list()
+        st.session_state[CHATBOT_TYPE] = current_chatbot_type
 
 
 def view_chat_history(avatar: dict[str, str]) -> None:


### PR DESCRIPTION
This PR includes:
1. Bug fix where conversation history was still showing up after chatbot type change.
2. Few constants change
3. Removed `page` from st.session and added `chatbot_type`


Closes #6 